### PR TITLE
Coercing input to TemplateBuilder so that @asset_types will be set properly

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -172,7 +172,7 @@ class UploadsController < OrganizationAwareController
       # Find out which builder is used to construct the template and create an instance
       builder = file_content_type.builder_name.constantize.new
       builder.organization = @organization
-      builder.asset_types = [template_proxy.asset_type]
+      builder.asset_types = [*template_proxy.asset_type]
       
       # Generate the spreadsheet. This returns a StringIO that has been rewound
       stream = builder.build


### PR DESCRIPTION
TemplateBuilder expects @asset_types to be enumerable, so make sure it is, whether it's a single item, an array (future flexibility) or nil (somebody dun goofed)