### PR TITLE
New user workflow

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -193,13 +193,15 @@ class UsersController < OrganizationAwareController
   # POST /users.json
   def create
 
-    @user = User.new(form_params)
-    @user.organization = @organization
+    new_user_service = get_user_service
+    @user = new_user_service.create_new_user(form_params)
+    @user.organization = @organization unless @user.organization # allow for mass-assignment of organization
 
     add_breadcrumb 'New'
 
     respond_to do |format|
       if @user.save
+        new_user_service.post_process(@user)
         notify_user(:notice, "User #{@user.name} was successfully created.")
         format.html { redirect_to user_url(@user) }
         format.json { render :json => @user, :status => :created, :location => @user }
@@ -322,6 +324,15 @@ class UsersController < OrganizationAwareController
   def check_for_cancel
     unless params[:cancel].blank?
       redirect_to user_url(current_user)
+    end
+  end
+
+  # Get the configured service to handle user creation, defaulting
+  def get_user_service
+    if Rails.application.config.new_user_service
+      Rails.application.config.new_user_service.constantize
+    else
+      DefaultNewUserService
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,8 @@ class User < ActiveRecord::Base
     :address2,
     :city,
     :state,
-    :zip
+    :zip,
+    :role_ids
   ]
 
   #------------------------------------------------------------------------------

--- a/app/services/default_new_user_service.rb
+++ b/app/services/default_new_user_service.rb
@@ -1,0 +1,11 @@
+class DefaultNewUserService
+  def self.create_new_user(form_params)
+    user = User.new(form_params)
+
+    return user
+  end
+
+  def self.post_process(user)
+    # No actions
+  end
+end

--- a/app/views/users/_user_settings_form.html.haml
+++ b/app/views/users/_user_settings_form.html.haml
@@ -7,8 +7,6 @@
     = dialog_tag('System Settings', {:icon => 'fa fa-cog', :class => "form_part"}) do
       = f.input :notify_via_email, :label => "Notify via Email" 
       = f.input :num_table_rows, :collection => [5,10,15,20,25,50,100], :include_blank => false, :label => "Number of table rows to display"
-      = f.button :submit, :class => "btn btn-primary"
-
       .col-md-12
         = f.button :submit, :class => "btn btn-primary"
 .col-md-3

--- a/app/views/users/_user_settings_form.html.haml
+++ b/app/views/users/_user_settings_form.html.haml
@@ -9,6 +9,8 @@
       = f.input :num_table_rows, :collection => [5,10,15,20,25,50,100], :include_blank => false, :label => "Number of table rows to display"
       = f.button :submit, :class => "btn btn-primary"
 
+      .col-md-12
+        = f.button :submit, :class => "btn btn-primary"
 .col-md-3
   = dialog_tag("Info", {:icon => "fa fa-question-circle", :class => "form_part"}) do
     %p Uncheck <strong>Notify via Email</strong> to turn off email notifications


### PR DESCRIPTION
Implementation of workflow for creation of a new user

- NewUserService holds the bare minimum logic to build a non-persisted user based on form input.  Persistance/Error Handling still occurs in the controller.  The user service can also be built on a by-deployment basis and configured to use that, instead of the default.  For instance, BPT uses it to ensure that roles fit the defined hierarchy (all managers are also users, e.g.)
  - The `post_process` step is intended to handle business logic that may arise.  For instance, BPT uses it to send a follow-up email to the created user
- adds role_ids to the FORM_PARAMS so that a user's role can be edited via form