### PR TITLE
Small changes to asset query form

### DIFF
--- a/app/views/searches/_asset_search_form.html.haml
+++ b/app/views/searches/_asset_search_form.html.haml
@@ -27,17 +27,15 @@
             = f.input_field :manufacture_year_comparator, :as => :hidden, :value => '0'
           = f.input_field :manufacture_year, :class => "form-control"
         = f.input :vendor_id, collection: Vendor.all, label: 'Vendor', input_html: { multiple: true }
-        = f.input :in_service_date, :wrapper => :vertical_prepend, :label => "Year Placed in Service" do
+        = f.input :in_service_date, :wrapper => :vertical_prepend, :label => "In Service Date" do
           .input-group-btn
             %button.btn.btn-default.dropdown-toggle{"data-toggle" => "dropdown", :type => "button"}
             %ul.dropdown-menu{:role => "menu"}
               %li
                 %a{:data => {:compare => "-1"}} Before
               %li
-                %a{:data => {:compare => "0"}} During
-              %li
                 %a{:data => {:compare => "1"}} After
-            = f.input_field :in_service_date_comparator, :as => :hidden, :value => '0'
+            = f.input_field :in_service_date_comparator, :as => :hidden, :value => '1'
           = f.date_field :in_service_date, :class => "form-control"
         = f.input :purchase_cost, :wrapper => :vertical_prepend do
           .input-group-btn
@@ -58,10 +56,8 @@
               %li
                 %a{:data => {:compare => "-1"}} Before
               %li
-                %a{:data => {:compare => "0"}} During
-              %li
                 %a{:data => {:compare => "1"}} After
-            = f.input_field :purchase_date_comparator, :as => :hidden, :value => '0'
+            = f.input_field :purchase_date_comparator, :as => :hidden, :value => '1'
           = f.date_field :purchase_date, :class => "form-control"
         = f.input :purchased_new, :as => :boolean, :label => "Purchased New", :label_html => { :class => 'bold' }
     .col-lg-3.col-md-6

--- a/app/views/searches/_asset_search_form.html.haml
+++ b/app/views/searches/_asset_search_form.html.haml
@@ -4,7 +4,6 @@
       %fieldset
         %legend.panel-legend Asset
         = f.input :organization_id, :collection => Organization.where(id: @organization_list), :label_method => 'coded_name' unless @organization_list.count < 2
-        = f.input :manufacturer_model, :placeholder => "Enter The Manufacturer Model"
         = f.input :keyword, :placeholder => "Enter A Query Term"
         = f.input :asset_type_id, :collection => AssetType.all, input_html: { multiple: true }, :label => "Type"
         = f.input :asset_subtype_id, :collection => AssetSubtype.all, :label => "Subtype", input_html: { multiple: true }
@@ -14,6 +13,7 @@
       %fieldset
         %legend.panel-legend Purchase
         = f.input :manufacturer_id, collection: Manufacturer.all, label_method: :full_name, input_html: { multiple: true }
+        = f.input :manufacturer_model, :placeholder => "Enter The Manufacturer Model"
         = f.input :manufacture_year, :wrapper => :vertical_prepend, :label => "Manufacture Year" do
           .input-group-btn
             %button.btn.btn-default.dropdown-toggle{"data-toggle" => "dropdown", :type => "button"}


### PR DESCRIPTION
This pull request only makes 3 small changes to how the basic asset search form is organized.  Namely, it makes these changes:

1. Moves the manufacturer model search to be closer to the other "manufacturer fields".
2. Relabels "Year Placed in Service" to "In Service Date" to more accurately reflect the data in the database (which is stored as a date, not a year).

3.  Removes the "during" option for single date queries, such as "In Service Date" because users will not realistically want to find only assets purchased on one particular date.