### PR TITLE
Fix data bleed on assets table

### DIFF
--- a/app/views/assets/_asset_compact_datatable.html.haml
+++ b/app/views/assets/_asset_compact_datatable.html.haml
@@ -22,7 +22,7 @@
       %th.center{:data => {:sortable => 'true', :order => 'desc'}} Status
 
   %tbody
-    - assets.each do |a|
+    - assets.where(organization_id: current_user.organization.id).each do |a|
       %tr{:id => a.object_key, :class => 'action-path'}
         %td.left= a.organization
         %td.left= a.asset_subtype

--- a/app/views/assets/_asset_compact_datatable.html.haml
+++ b/app/views/assets/_asset_compact_datatable.html.haml
@@ -22,7 +22,7 @@
       %th.center{:data => {:sortable => 'true', :order => 'desc'}} Status
 
   %tbody
-    - assets.where(organization_id: current_user.organization.id).each do |a|
+    - assets.joins("INNER JOIN users_organizations").where('assets.organization_id = users_organizations.organization_id').where( 'users_organizations.user_id = ?', current_user.id).uniq.each do |a|
       %tr{:id => a.object_key, :class => 'action-path'}
         %td.left= a.organization
         %td.left= a.asset_subtype

--- a/app/views/assets/_asset_table.html.haml
+++ b/app/views/assets/_asset_table.html.haml
@@ -34,7 +34,7 @@
       %th.center.sorting_disabled.icon-column Flags
 
   %tbody
-    - assets.where(organization_id: current_user.organization.id ).includes(:organization, :asset_subtype).each do |a|
+    - assets.includes(:organization, :asset_subtype).each do |a|
       %tr{:id => a.object_key, :class => 'action-path'}
         - SystemConfig.transam_module_names.each do |mod|
           - if lookup_context.template_exists?("#{mod}_asset_dt_columns", "assets", true)

--- a/app/views/assets/_asset_table.html.haml
+++ b/app/views/assets/_asset_table.html.haml
@@ -34,7 +34,7 @@
       %th.center.sorting_disabled.icon-column Flags
 
   %tbody
-    - assets.includes(:organization, :asset_subtype).each do |a|
+    - assets.where(organization_id: current_user.organization.id ).includes(:organization, :asset_subtype).each do |a|
       %tr{:id => a.object_key, :class => 'action-path'}
         - SystemConfig.transam_module_names.each do |mod|
           - if lookup_context.template_exists?("#{mod}_asset_dt_columns", "assets", true)


### PR DESCRIPTION
This pull request changes the asset data compact table so that it only displays assets belonging to organizations that the user has access to.