### PR TITLE
Edited the format asset group helper so that it only displays three t…

### DIFF
--- a/app/helpers/transam_format_helper.rb
+++ b/app/helpers/transam_format_helper.rb
@@ -39,11 +39,12 @@ module TransamFormatHelper
   # formats an assets list of asset groups with remove option
   def format_asset_groups(asset, style = 'info')
     html = ""
-    asset.asset_groups.each do |grp|
+    asset.asset_groups.each_with_index do |grp, index|
       html << "<span class='label label-#{style}'>"
       html << grp.code
       html << "<span data-role='remove' data-action-path='#{remove_from_group_inventory_path(asset, :asset_group => grp)}'></span>"
       html << "</span>"
+      html << "<br>" if (index + 1) % 3 == 0
     end
     html.html_safe
   end


### PR DESCRIPTION
…ags per line.  [#98220562]

1.  This pull request fixes a UI issue where placing 4 or more asset tags on a single asset would cause the tags to bleed over into other columns.  It starts a new line every three asset tags to avoid this issue.