### PR TITLE
Fix organization table

### DIFF
--- a/app/views/organizations/_index_table.html.haml
+++ b/app/views/organizations/_index_table.html.haml
@@ -35,11 +35,11 @@
       %th.left{:data => {:sortable => 'true'}} Web Site
   %tbody
     - organizations.each do |o|
-      %tr{:id => o.short_name, :class => 'action-path'}
+      %tr{ :class => 'action-path' }
         %td= o.id
         %td= o.external_id
         %td= o.organization_type
-        %td= o.short_name
+        %td= link_to( "#{o.short_name}", organization_path(o.short_name))
         %td= o.name
         %td= format_as_address(o)
         %td= o.address1

--- a/app/views/users/_index_table.html.haml
+++ b/app/views/users/_index_table.html.haml
@@ -43,13 +43,13 @@
 
   %tbody
     - @users.each do |u|
-      %tr{:id => u.object_key, :class => 'action-path'}
+      %tr{ :class => 'action-path' }
         %td= u.object_key
         %td= u.external_id
-        %td= u.organization.short_name
+        %td= link_to( u.organization.short_name, organization_path(u.organization.short_name))
         %td= u.title
-        %td= u.first_name
-        %td= u.last_name
+        %td= link_to( u.first_name, user_path(u.object_key))
+        %td= link_to( u.last_name, user_path(u.object_key))
         %td= u.email
         %td= format_as_phone_number(u.phone)
         %td= u.timezone


### PR DESCRIPTION
This pull request changes the behavior of the organizations table and the users table so that clicking on a row no longer redirects the user to the detail page.