### PR TITLE
Change min to zero for condition

### DIFF
--- a/app/models/condition_type.rb
+++ b/app/models/condition_type.rb
@@ -2,7 +2,7 @@ class ConditionType < ActiveRecord::Base
 
   # All types that are available
   scope :active, -> { where(:active => true) }
- 
+
   def self.max_rating
     order("rating DESC").first.rating
   end
@@ -21,8 +21,10 @@ class ConditionType < ActiveRecord::Base
       rating = 3
     elsif estimated_rating >= 2.0
       rating = 2
-    else
+    elsif estimated_rating >= 1.0
       rating = 1
+    else
+      rating = 0
     end
     ConditionType.find_by_rating(rating)
   end

--- a/app/models/condition_type.rb
+++ b/app/models/condition_type.rb
@@ -21,7 +21,7 @@ class ConditionType < ActiveRecord::Base
       rating = 3
     elsif estimated_rating >= 2.0
       rating = 2
-    elsif estimated_rating >= 1.0
+    elsif estimated_rating > 0
       rating = 1
     else
       rating = 0

--- a/app/views/asset_events/_condition_update_event_form.html.haml
+++ b/app/views/asset_events/_condition_update_event_form.html.haml
@@ -1,5 +1,5 @@
 = render :layout => "update_event_form" do |f|
-  = f.input :assessed_rating, :as => :float, :input_html => {:min => ConditionType.min_rating, :max => ConditionType.max_rating}
+  = f.input :assessed_rating, :as => :float, :input_html => {:min => 0, :max => ConditionType.max_rating}
   = f.input :event_date, :label => 'Date of Report', :wrapper => :vertical_append do
     = f.input_field :event_date, :class => "form-control", :as => :string, :data => {'behavior' => 'datepicker'}, :value => format_as_date(f.object.event_date)
     %span.input-group-addon


### PR DESCRIPTION
This pull request addresses an issue where the notes for the condition update event form indicate that the user can input 0.0 to indicate that the asset's condition is unknown.  Previously, the form would actually prevent the user from inputing values less than 1.0 

The user can now input 0.0 to indicate that the asset's condition is unknown.  Right now, any rating above 0.0 will result in the condition type being listed as something other than unknown.  For example, inputing a 0.1 will result in the asset being listed as being in "poor" condition.  I can change this pretty easily though, if this is not the desired behavior.  