### PR TITLE
Modified the condition update notes so that it lists the name of the …

### DIFF
--- a/app/views/asset_events/_condition_update_event_notes.html.haml
+++ b/app/views/asset_events/_condition_update_event_notes.html.haml
@@ -1,12 +1,12 @@
 %p
   Use the following scale to determine the correct rating for the asset. You
   can enter fractional values such as <strong>4.5</strong> or <strong>2.75</strong> .
-  
+
 %dl.dl-horizontal
   - ConditionType.all.reverse.each do |x|
     %dt{:style => 'width:60px;margin-bottom:10px;'}= "#{x.rating}"
-    %dd{:style => 'margin-left:80px;;margin-bottom:5px;'}= "#{x.description}"
+    %dd{:style => 'margin-left:80px;;margin-bottom:5px;'}= "#{x.name} - #{x.description}"
 
 %p
   Note that the FTA ranks any asset with a condition rating <strong>&lt 2.5</strong> as in need of replacement.
-  
+


### PR DESCRIPTION
…condition type next to the condition type's description.  The summary on the left uses the name, so this change will make it easier for the user to match the condition type name to the corresponding number.  [#98133264]