### PR TITLE
Condition update notes

### DIFF
--- a/app/views/asset_events/_condition_update_event_notes.html.haml
+++ b/app/views/asset_events/_condition_update_event_notes.html.haml
@@ -4,8 +4,9 @@
 
 %dl.dl-horizontal
   - ConditionType.all.reverse.each do |x|
-    %dt{:style => 'width:60px;margin-bottom:10px;'}= "#{x.rating}"
-    %dd{:style => 'margin-left:80px;;margin-bottom:5px;'}= "#{x.name} - #{x.description}"
+    - if x.name != "Unknown"
+      %dt{:style => 'width:60px;margin-bottom:10px;'}= "#{x.rating}"
+      %dd{:style => 'margin-left:80px;;margin-bottom:5px;'}= "#{x.name} - #{x.description}"
 
 %p
   Note that the FTA ranks any asset with a condition rating <strong>&lt 2.5</strong> as in need of replacement.

--- a/app/views/asset_events/_condition_update_event_notes.html.haml
+++ b/app/views/asset_events/_condition_update_event_notes.html.haml
@@ -1,12 +1,12 @@
 %p
   Use the following scale to determine the correct rating for the asset. You
   can enter fractional values such as <strong>4.5</strong> or <strong>2.75</strong> .
-  
+
 %dl.dl-horizontal
   - ConditionType.all.reverse.each do |x|
     %dt{:style => 'width:60px;margin-bottom:10px;'}= "#{x.rating}"
-    %dd{:style => 'margin-left:80px;;margin-bottom:5px;'}= "#{x.description}"
+    %dd{:style => 'margin-left:80px;;margin-bottom:5px;'}= "#{x.name} - #{x.description}"
 
 %p
   Note that the FTA ranks any asset with a condition rating <strong>&lt 2.5</strong> as in need of replacement.
-  
+


### PR DESCRIPTION
Modified the condition update notes so that it no longer shows the description for the "Unknown" condition type.

Also, added the name in front of the description for each condition type description so that users can more easily match the condition types that they see in the asset summary to the description when they are inputing the new condition type.