### PR TITLE
Backlog update

### DIFF
--- a/app/reports/backlog_report.rb
+++ b/app/reports/backlog_report.rb
@@ -1,23 +1,24 @@
 class BacklogReport < AbstractReport
+  include FiscalYear
 
   def initialize(attributes = {})
     super(attributes)
-  end    
-  
+  end
+
   def get_data(organization_id_list, params)
-    
+
     # Check to see if we got an asset type to sub select on
-    if params[:report_filter_type] 
+    if params[:report_filter_type]
       report_filter_type = params[:report_filter_type].to_i
     else
       report_filter_type = 0
     end
-        
+
     # get the list of assets for this agency
     if report_filter_type > 0
-      assets = Asset.where('organization_id IN (?) AND assets.asset_type_id = ? AND assets.in_backlog = ?', organization_id_list, report_filter_type, true).order('asset_type_id, asset_subtype_id')
+      assets = Asset.where('organization_id IN (?) AND assets.asset_type_id = ? AND assets.policy_replacement_year < ?', organization_id_list, report_filter_type, current_fiscal_year_year).order('asset_type_id, asset_subtype_id')
     else
-      assets = Asset.where("organization_id IN (?) AND assets.in_backlog = ?", organization_id_list, true).order('asset_type_id, asset_subtype_id')
+      assets = Asset.where("organization_id IN (?) AND assets.policy_replacement_year < ?", organization_id_list, current_fiscal_year_year).order('asset_type_id, asset_subtype_id')
     end
 
     a = {}
@@ -32,7 +33,7 @@ class BacklogReport < AbstractReport
       # get the replacement cost for this item based on the current policy
       report_row.add(asset)
       end
-    return a          
+    return a
   end
-  
+
 end

--- a/app/reports/backlog_report.rb
+++ b/app/reports/backlog_report.rb
@@ -16,9 +16,9 @@ class BacklogReport < AbstractReport
 
     # get the list of assets for this agency
     if report_filter_type > 0
-      assets = Asset.where('organization_id IN (?) AND assets.asset_type_id = ? AND assets.policy_replacement_year < ?', organization_id_list, report_filter_type, current_fiscal_year_year).order('asset_type_id, asset_subtype_id')
+      assets = Asset.where('organization_id IN (?) AND assets.asset_type_id = ? AND assets.policy_replacement_year <= ?', organization_id_list, report_filter_type, current_planning_year_year).order('asset_type_id, asset_subtype_id')
     else
-      assets = Asset.where("organization_id IN (?) AND assets.policy_replacement_year < ?", organization_id_list, current_fiscal_year_year).order('asset_type_id, asset_subtype_id')
+      assets = Asset.where("organization_id IN (?) AND assets.policy_replacement_year <= ?", organization_id_list, current_planning_year_year).order('asset_type_id, asset_subtype_id')
     end
 
     a = {}


### PR DESCRIPTION
This pull request makes a change to the query used for the backlog report.  Previously, the query pulled assets flagged as in backlog.  This pull request changes it so that it now looks for assets with policy replacement years less than or equal to the current planning year.