### PR TITLE
Auto add policy rules

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -583,6 +583,7 @@ class AssetsController < AssetAwareController
     policy = asset.policy
     grantor_policy = policy.parent
 
+    #Grantors Policies do not have parents, and we do not need to add new rules
     if grantor_policy.present?
       grantor_policy.policy_asset_type_rules.each do |rule|
         asset_count = Asset.where(organization_id: policy.organization.id, asset_type: rule.asset_type).count

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -595,7 +595,7 @@ class AssetsController < AssetAwareController
           if asset_count == 1
             new_rule = rule.dup
             new_rule.policy = policy
-            new_rule.save!
+            new_rule.save
           end
         end
       end
@@ -610,7 +610,7 @@ class AssetsController < AssetAwareController
           if asset_count == 1
             new_rule = rule.dup
             new_rule.policy = policy
-            new_rule.save!
+            new_rule.save
           end
         end
       end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -278,6 +278,7 @@ class AssetsController < AssetAwareController
 
     respond_to do |format|
       if @asset.save
+        ensure_policy_rules_for_asset(@asset)
         # If the asset was successfully saved, schedule update the condition and disposition asynchronously
         Delayed::Job.enqueue AssetUpdateJob.new(@asset.object_key), :priority => 0
 
@@ -576,6 +577,32 @@ class AssetsController < AssetAwareController
         end
       end
     end
+  end
+
+  def ensure_policy_rules_for_asset(asset)
+    policy = asset.policy
+    grantor_policy = policy.parent
+
+    if grantor_policy.present?
+      grantor_policy.policy_asset_type_rules.each do |rule|
+        asset_count = Asset.where(organization_id: policy.organization.id, asset_type: rule.asset_type).count
+        if asset_count > 0
+          new_rule = rule.dup
+          new_rule.policy = policy
+          new_rule.save!
+        end
+      end
+
+      grantor_policy.policy_asset_subtype_rules.each do |rule|
+        asset_count = Asset.where(organization_id: policy.organization.id, asset_subtype: rule.asset_subtype).count
+        if asset_count > 0
+          new_rule = rule.dup
+          new_rule.policy = policy
+          new_rule.save!
+        end
+      end
+    end
+
   end
 
   #------------------------------------------------------------------------------

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -586,20 +586,28 @@ class AssetsController < AssetAwareController
     #Grantors Policies do not have parents, and we do not need to add new rules
     if grantor_policy.present?
       grantor_policy.policy_asset_type_rules.each do |rule|
-        asset_count = Asset.where(organization_id: policy.organization.id, asset_type: rule.asset_type).count
-        if asset_count > 0
-          new_rule = rule.dup
-          new_rule.policy = policy
-          new_rule.save!
+
+        # Only create rules for the new asset.
+        if rule.asset_type == asset.asset_type
+          asset_count = Asset.where(organization_id: policy.organization.id, asset_type: rule.asset_type).count
+          if asset_count > 0
+            new_rule = rule.dup
+            new_rule.policy = policy
+            new_rule.save!
+          end
         end
       end
 
       grantor_policy.policy_asset_subtype_rules.each do |rule|
-        asset_count = Asset.where(organization_id: policy.organization.id, asset_subtype: rule.asset_subtype).count
-        if asset_count > 0
-          new_rule = rule.dup
-          new_rule.policy = policy
-          new_rule.save!
+
+        # Only create rules for the new asset.
+        if rule.asset_subtype == asset.asset_subtype
+          asset_count = Asset.where(organization_id: policy.organization.id, asset_subtype: rule.asset_subtype).count
+          if asset_count > 0
+            new_rule = rule.dup
+            new_rule.policy = policy
+            new_rule.save!
+          end
         end
       end
     end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -590,7 +590,9 @@ class AssetsController < AssetAwareController
         # Only create rules for the new asset.
         if rule.asset_type == asset.asset_type
           asset_count = Asset.where(organization_id: policy.organization.id, asset_type: rule.asset_type).count
-          if asset_count > 0
+
+          # Only create rules if this is the first asset of this type.
+          if asset_count == 1
             new_rule = rule.dup
             new_rule.policy = policy
             new_rule.save!
@@ -603,7 +605,9 @@ class AssetsController < AssetAwareController
         # Only create rules for the new asset.
         if rule.asset_subtype == asset.asset_subtype
           asset_count = Asset.where(organization_id: policy.organization.id, asset_subtype: rule.asset_subtype).count
-          if asset_count > 0
+
+          # Only create rules if this is the first asset of this subtype
+          if asset_count == 1
             new_rule = rule.dup
             new_rule.policy = policy
             new_rule.save!


### PR DESCRIPTION
This branch previously had an error that it would add rules any time an organization added a new asset.  Now, it only creates rules when it acquires an asset type or asset subtype for the first time.