### PR TITLE
Add rule methods

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -270,6 +270,10 @@ class AssetsController < AssetAwareController
     @asset.creator = current_user
     @asset.updator = current_user
 
+    # Create policy rules if the organization needs new rules for that asset type or subtype
+    policy = @asset.policy
+    policy.ensure_rules_for_asset(@asset) if @asset.valid?
+
     #Rails.logger.debug @asset.inspect
 
     add_breadcrumb "#{asset_type.name}".pluralize(2), inventory_index_path(:asset_type => asset_subtype.asset_type)

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -270,10 +270,6 @@ class AssetsController < AssetAwareController
     @asset.creator = current_user
     @asset.updator = current_user
 
-    # Create policy rules if the organization needs new rules for that asset type or subtype
-    policy = @asset.policy
-    policy.ensure_rules_for_asset(@asset) if @asset.valid?
-
     #Rails.logger.debug @asset.inspect
 
     add_breadcrumb "#{asset_type.name}".pluralize(2), inventory_index_path(:asset_type => asset_subtype.asset_type)
@@ -282,6 +278,11 @@ class AssetsController < AssetAwareController
 
     respond_to do |format|
       if @asset.save
+        # If this policy is a parent policy, check to see if it has rules for this asset.
+        # For other policies, add rules from the parent policy if this policy lacks rules for this asset.
+
+        policy = @asset.policy
+        policy.ensure_rules_for_asset(@asset)
         # If the asset was successfully saved, schedule update the condition and disposition asynchronously
         Delayed::Job.enqueue AssetUpdateJob.new(@asset.object_key), :priority => 0
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -103,7 +103,7 @@ class Policy < ActiveRecord::Base
   def load_type_rules_from_parent(asset_type)
 
     if parent.present?
-      parent_rules = parent.policy_asset_type_rules.where(asset_type: asset_type)
+      parent_rules = parent.policy_asset_type_rules.find_by(asset_type: asset_type)
       parent_rules.each do |parent_rule|
         new_rule = parent_rule.dup
         new_rule.policy = self

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -92,12 +92,12 @@ class Policy < ActiveRecord::Base
 
   def require_type_rules_for_asset_type?(asset_type)
     # We should only create rules when the organization first acquires an asset type
-    !Asset.exists?(organization: self.organization, asset_type: asset_type)
+    !PolicyAssetTypeRule.exists?(policy: self, asset_type: asset_type)
   end
 
   def require_subtype_rules_for_asset_subtype?(asset_subtype)
     # We should only create rules when the organization first acquires an asset subtype
-    !Asset.exists?(organization: self.organization, asset_subtype: asset_subtype)
+    !PolicyAssetSubtypeRule.exists?(policy: self, asset_subtype: asset_subtype)
   end
 
   def load_type_rules_from_parent(asset_type)

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -90,13 +90,13 @@ class Policy < ActiveRecord::Base
     name
   end
 
-  def require_type_rules_for_asset_type?(asset_type)
-    # We should only create rules when the organization first acquires an asset type
+  def missing_type_rules_for_asset_type?(asset_type)
+    # This method checks to see if this policy has the right rule for this asset type
     !PolicyAssetTypeRule.exists?(policy: self, asset_type: asset_type)
   end
 
-  def require_subtype_rules_for_asset_subtype?(asset_subtype)
-    # We should only create rules when the organization first acquires an asset subtype
+  def missing_subtype_rules_for_asset_subtype?(asset_subtype)
+    # This method checks to see if this policy has the right rule for this asset subtype
     !PolicyAssetSubtypeRule.exists?(policy: self, asset_subtype: asset_subtype)
   end
 
@@ -104,7 +104,7 @@ class Policy < ActiveRecord::Base
     # When initially creating rules for a new asset type, look to the parent policy to create the default rules for that subtype
     # This method uses a rescue block to handle cases where the parent policy does not have an appropriate rule
     begin
-      parent_rule = parent.policy_asset_type_rules.find_by(asset_type: asset_type)
+      parent_rule = PolicyAssetTypeRule.find_by(policy: parent, asset_type: asset_type)
       new_rule = parent_rule.dup
       new_rule.policy = self
       new_rule.save
@@ -114,10 +114,10 @@ class Policy < ActiveRecord::Base
   end
 
   def load_subtype_rules_from_parent(asset_subtype)
-    # When initially creating rules for a new subtype, look to the parent policy to create the default rules for that subtype
+    # When initially creating rules for a new asset type, look to the parent policy to create the default rules for that subtype
     # This method uses a rescue block to handle cases where the parent policy does not have an appropriate rule
     begin
-      parent_rule = parent.policy_asset_subtype_rules.find_by(asset_subtype: asset_subtype)
+      parent_rule = PolicyAssetSubtypeRule.find_by(policy: parent, asset_subtype: asset_subtype)
       new_rule = parent_rule.dup
       new_rule.policy = self
       new_rule.save
@@ -126,29 +126,23 @@ class Policy < ActiveRecord::Base
     end
   end
 
-  def check_for_type_rule(asset_type)
-    raise Exception.new("This policy does not have a asset type rule for #{asset_type}") if !PolicyAssetTypeRule.exists?(policy: self, asset_type: asset_type)
-  end
-
-  def check_for_subtype_rule(asset_subtype)
-    raise Exception.new("This policy does not have a asset type rule for #{asset_subtype}") if !PolicyAssetTypeRule.exists?(policy: self, asset_subtype: asset_subtype)
-  end
-
-  def check_for_asset_rules(asset)
-    begin
-      check_for_type_rule(asset.asset_type)
-      check_for_subtype_rule(asset.asset_subtype)
-    rescue Exception
-      Rails.logger.warn Exception
+  def check_self_for_asset_rules(asset)
+    if missing_type_rules_for_asset_type?(asset.asset_type)
+      raise StandardError.new("#{ self } is missing rules for #{ asset.asset_type.pluralize }.")
+    elsif missing_subtype_rules_for_asset_subtype?(asset.asset_subtype)
+      raise StandardError.new("#{ self } is missing rules for #{ asset.asset_subtype.pluralize }.")
     end
   end
 
   def ensure_rules_for_asset(asset)
+    # This method checks to see if this policy is a parent policy.  If it is, it checks to see if it has the right rules for the asset.
+    # If this policy is not a parent policy, then it checks to see if it has the right rules for the asset, and then loads missing rules from the parent.
+
     if parent.present?
-      load_type_rules_from_parent(asset.asset_type) if require_type_rules_for_asset_type?(asset.asset_type)
-      load_subtype_rules_from_parent(asset.asset_subtype) if require_subtype_rules_for_asset_subtype?(asset.asset_subtype)
+      load_type_rules_from_parent(asset.asset_type) if missing_type_rules_for_asset_type?(asset.asset_type)
+      load_subtype_rules_from_parent(asset.asset_subtype) if missing_subtype_rules_for_asset_subtype?(asset.asset_subtype)
     else
-      check_for_asset_rules(asset)
+      check_self_for_asset_rules(asset)
     end
   end
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -115,7 +115,7 @@ class Policy < ActiveRecord::Base
 
   def load_subtype_rules_from_parent(asset_subtype)
     # When initially creating rules for a new subtype, look to the parent policy to create the default rules for that subtype
-        # This method uses a rescue block to handle cases where the parent policy does not have an appropriate rule
+    # This method uses a rescue block to handle cases where the parent policy does not have an appropriate rule
     begin
       parent_rule = parent.policy_asset_subtype_rules.find_by(asset_subtype: asset_subtype)
       new_rule = parent_rule.dup
@@ -126,9 +126,30 @@ class Policy < ActiveRecord::Base
     end
   end
 
+  def check_for_type_rule(asset_type)
+    raise Exception.new("This policy does not have a asset type rule for #{asset_type}") if !PolicyAssetTypeRule.exists?(policy: self, asset_type: asset_type)
+  end
+
+  def check_for_subtype_rule(asset_subtype)
+    raise Exception.new("This policy does not have a asset type rule for #{asset_subtype}") if !PolicyAssetTypeRule.exists?(policy: self, asset_subtype: asset_subtype)
+  end
+
+  def check_for_asset_rules(asset)
+    begin
+      check_for_type_rule(asset.asset_type)
+      check_for_subtype_rule(asset.asset_subtype)
+    rescue Exception
+      Rails.logger.warn Exception
+    end
+  end
+
   def ensure_rules_for_asset(asset)
-    load_type_rules_from_parent(asset.asset_type) if require_type_rules_for_asset_type?(asset.asset_type)
-    load_subtype_rules_from_parent(asset.asset_subtype) if require_subtype_rules_for_asset_subtype?(asset.asset_subtype)
+    if parent.present?
+      load_type_rules_from_parent(asset.asset_type) if require_type_rules_for_asset_type?(asset.asset_type)
+      load_subtype_rules_from_parent(asset.asset_subtype) if require_subtype_rules_for_asset_subtype?(asset.asset_subtype)
+    else
+      check_for_asset_rules(asset)
+    end
   end
 
   #------------------------------------------------------------------------------

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -101,26 +101,22 @@ class Policy < ActiveRecord::Base
   end
 
   def load_type_rules_from_parent(asset_type)
-
+    # When initially creating rules for a new asset type, look to the parent policy to create the default rules for that subtype
     if parent.present?
-      parent_rules = parent.policy_asset_type_rules.find_by(asset_type: asset_type)
-      parent_rules.each do |parent_rule|
-        new_rule = parent_rule.dup
-        new_rule.policy = self
-        new_rule.save
-      end
+      parent_rule = parent.policy_asset_type_rules.find_by(asset_type: asset_type)
+      new_rule = parent_rule.dup
+      new_rule.policy = self
+      new_rule.save
     end
   end
 
   def load_subtype_rules_from_parent(asset_subtype)
-
+    # When initially creating rules for a new subtype, look to the parent policy to create the default rules for that subtype
     if parent.present?
-      parent_rules = parent.policy_asset_subtype_rules.where(asset_subtype: asset_subtype)
-      parent_rules.each do |parent_rule|
-        new_rule = parent_rule.dup
-        new_rule.policy = self
-        new_rule.save
-      end
+      parent_rule = parent.policy_asset_subtype_rules.find_by(asset_subtype: asset_subtype)
+      new_rule = parent_rule.dup
+      new_rule.policy = self
+      new_rule.save
     end
   end
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -127,6 +127,7 @@ class Policy < ActiveRecord::Base
   end
 
   def check_self_for_asset_rules(asset)
+    # This method is for parent policies.  It checks to see if the parent policy has the right rules for the asset.
     if missing_type_rules_for_asset_type?(asset.asset_type)
       raise StandardError.new("#{ self } is missing rules for #{ asset.asset_type.pluralize }.")
     elsif missing_subtype_rules_for_asset_subtype?(asset.asset_subtype)

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -138,11 +138,15 @@ class Policy < ActiveRecord::Base
     # This method checks to see if this policy is a parent policy.  If it is, it checks to see if it has the right rules for the asset.
     # If this policy is not a parent policy, then it checks to see if it has the right rules for the asset, and then loads missing rules from the parent.
 
-    if parent.present?
-      load_type_rules_from_parent(asset.asset_type) if missing_type_rules_for_asset_type?(asset.asset_type)
-      load_subtype_rules_from_parent(asset.asset_subtype) if missing_subtype_rules_for_asset_subtype?(asset.asset_subtype)
-    else
-      check_self_for_asset_rules(asset)
+    begin
+      if parent.present?
+        load_type_rules_from_parent(asset.asset_type) if missing_type_rules_for_asset_type?(asset.asset_type)
+        load_subtype_rules_from_parent(asset.asset_subtype) if missing_subtype_rules_for_asset_subtype?(asset.asset_subtype)
+      else
+        check_self_for_asset_rules(asset)
+      end
+    rescue Exception => e
+      Rails.logger.warn e.message
     end
   end
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -102,21 +102,27 @@ class Policy < ActiveRecord::Base
 
   def load_type_rules_from_parent(asset_type)
     # When initially creating rules for a new asset type, look to the parent policy to create the default rules for that subtype
-    if parent.present?
+    # This method uses a rescue block to handle cases where the parent policy does not have an appropriate rule
+    begin
       parent_rule = parent.policy_asset_type_rules.find_by(asset_type: asset_type)
       new_rule = parent_rule.dup
       new_rule.policy = self
       new_rule.save
+    rescue Exception => e
+      Rails.logger.warn e.message
     end
   end
 
   def load_subtype_rules_from_parent(asset_subtype)
     # When initially creating rules for a new subtype, look to the parent policy to create the default rules for that subtype
-    if parent.present?
+        # This method uses a rescue block to handle cases where the parent policy does not have an appropriate rule
+    begin
       parent_rule = parent.policy_asset_subtype_rules.find_by(asset_subtype: asset_subtype)
       new_rule = parent_rule.dup
       new_rule.policy = self
       new_rule.save
+    rescue Exception => e
+      Rails.logger.warn e.message
     end
   end
 


### PR DESCRIPTION
This branch creates a series of methods that policies can use to find if they have the correct rules for an asset.  If this branch is merged, the policy can use a single method to check if it is missing the rules for the asset type or subtype, and it can load the appropriate rule from the parent policy.

If the policy happens to be a parent policy, the app will determine if has rules for the asset's type and subtype.  It will raise an exception if it does not have the appropriate rules.

Right now, the app uses rescue blocks to continue on if it encounters an exception.  It will log the error and continue.  This behavior can be changed pretty easily if this is not the intended behavior.