### PR TITLE
[119079973] if the date is equal to Date.new(1) it replaces this date…

### DIFF
--- a/app/helpers/transam_format_helper.rb
+++ b/app/helpers/transam_format_helper.rb
@@ -215,9 +215,9 @@ module TransamFormatHelper
 
   def format_as_date(date, compact=true)
     if compact
-      date.strftime("%m/%d/%Y") unless date.nil?
+      date.strftime("%m/%d/%Y") unless (date.nil? || date == Date.new(1))
     else
-      date.strftime("%b %d %Y") unless date.nil?
+      date.strftime("%b %d %Y") unless (date.nil? || date == Date.new(1))
     end
   end
 

--- a/app/helpers/transam_format_helper.rb
+++ b/app/helpers/transam_format_helper.rb
@@ -215,9 +215,9 @@ module TransamFormatHelper
 
   def format_as_date(date, compact=true)
     if compact
-      date.strftime("%m/%d/%Y") unless (date.nil? || date == Date.new(1))
+      date.strftime("%m/%d/%Y") unless (date.nil? || date.year == 1)
     else
-      date.strftime("%b %d %Y") unless (date.nil? || date == Date.new(1))
+      date.strftime("%b %d %Y") unless (date.nil? || date.year == 1)
     end
   end
 


### PR DESCRIPTION
… with null for the front end display.


This is something we need to do for SIMS, often times when we need a default date it is being set to Date.new(1). Sims uses the core format helper, but I didn't want to merge this pull request in without first having somebody look at it.