### PR TITLE
Support job priority configuration for each job class [fixes#114089393]

### DIFF
--- a/app/models/delayed_job_priority.rb
+++ b/app/models/delayed_job_priority.rb
@@ -1,0 +1,14 @@
+#-------------------------------------------------------------------------------
+#
+# DelayedJobPriority
+#
+# Configure priority for each job class.
+#
+#-------------------------------------------------------------------------------
+class DelayedJobPriority < ActiveRecord::Base
+  #-----------------------------------------------------------------------------
+  # Validations
+  #-----------------------------------------------------------------------------
+  validates :class_name,              :presence => true, :uniqueness => true
+  validates :priority,                :presence => true, numericality: { only_integer: true }
+end

--- a/config/initializers/deplayed_job_set_priority_plugin.rb
+++ b/config/initializers/deplayed_job_set_priority_plugin.rb
@@ -8,7 +8,7 @@ module Delayed
             job_class_name = YAML.load(job.handler).try(:class).try(:name)
             if job_class_name.present?
               priority = DelayedJobPriority.find_by_class_name(job_class_name).try(:priority)
-              if priority != job.priority
+              if priority.present? && priority != job.priority
                 job.priority = priority
               end
             end

--- a/config/initializers/deplayed_job_set_priority_plugin.rb
+++ b/config/initializers/deplayed_job_set_priority_plugin.rb
@@ -1,0 +1,22 @@
+module Delayed
+  module Plugins
+    class SetPriorityPlugin < Plugin
+      callbacks do |lifecycle|
+        lifecycle.before(:enqueue) do |job, *args, &block|
+          if (DelayedJobPriority rescue false)
+            # setting priority based on configuration...
+            job_class_name = YAML.load(job.handler).try(:class).try(:name)
+            if job_class_name.present?
+              priority = DelayedJobPriority.find_by_class_name(job_class_name).try(:priority)
+              if priority != job.priority
+                job.priority = priority
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Delayed::Worker.plugins << Delayed::Plugins::SetPriorityPlugin

--- a/db/migrate/20170103225100_add_delayed_job_priorities.rb
+++ b/db/migrate/20170103225100_add_delayed_job_priorities.rb
@@ -1,0 +1,10 @@
+class AddDelayedJobPriorities < ActiveRecord::Migration
+  def change
+    create_table :delayed_job_priorities do |t|
+      t.string :class_name,     null: false
+      t.integer :priority,      null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102174139) do
+ActiveRecord::Schema.define(version: 20170103225100) do
 
   create_table "activities", force: true do |t|
     t.string   "object_key",           limit: 12
@@ -347,6 +347,13 @@ ActiveRecord::Schema.define(version: 20161102174139) do
     t.boolean  "active",                     null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+  end
+
+  create_table "delayed_job_priorities", force: true do |t|
+    t.string   "class_name",             null: false
+    t.integer  "priority",   default: 0, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "delayed_jobs", force: true do |t|

--- a/spec/factories/delayed_job_priorities.rb
+++ b/spec/factories/delayed_job_priorities.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :delayed_job_priority do
+    sequence :class_name do |n|
+      "AssetUpdateJob#{n}"
+    end
+    priority -10
+  end
+end

--- a/spec/jobs/delayed_job_priority_spec.rb
+++ b/spec/jobs/delayed_job_priority_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe DelayedJobPriority, :type => :job do
+  it 'changes priority' do
+    test_priority = create(:delayed_job_priority, class_name: 'AssetUpdateJob', priority: -10)
+    test_asset = create(:buslike_asset)
+    test_job = Delayed::Job.enqueue(AssetUpdateJob.new(test_asset.object_key), :priority => 0)
+    
+    expect(test_job.priority).to eq(-10)
+  end
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |config|
 
-  DatabaseCleaner.strategy = :truncation, {:only => %w[assets asset_events asset_event_asset_subsystems asset_groups asset_groups_assets asset_subsystems asset_subtypes asset_types fuel_types maintenance_types manufacturers messages notices policies policy_asset_type_rules policy_asset_subtype_rules organizations organization_types tasks users users_organizations user_organization_filters user_organization_filters_organizations users_roles weather_codes]}
+  DatabaseCleaner.strategy = :truncation, {:only => %w[assets asset_events asset_event_asset_subsystems asset_groups asset_groups_assets asset_subsystems asset_subtypes asset_types fuel_types maintenance_types manufacturers messages notices policies policy_asset_type_rules policy_asset_subtype_rules organizations organization_types tasks users users_organizations user_organization_filters user_organization_filters_organizations users_roles weather_codes delayed_job_priorities]}
   # DatabaseCleaner.strategy = :transaction
   config.before(:suite) do
     begin


### PR DESCRIPTION
1. delayed_job_priorities table is to set priority for each job class_name, e.g., set priority as 10 for AssetUpdateJob.

2. The configuration priority would be picked up before enqueue action. If there is no configuration, then whatever priority was used in the enqueue is left as-is.