### PR TITLE
Uom (unit of measurement) and test image fix

### DIFF
--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     association :creator, factory: :normal_user
     original_filename 'test_pic.png'
     description 'Test Image'
-    image { Rack::Test::UploadedFile.new(File.join(TransamCore::Engine.root, 'spec', 'support', 'test_files', 'test_pic.png')) }
+    image { Rack::Test::UploadedFile.new(File.join(TransamCore::Engine.root, 'spec', 'support', 'test_files', 'test_pic.png'), 'image/png') }
     imagable_type 'Asset'
   end
 end

--- a/transam_core.gemspec
+++ b/transam_core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "high_voltage"
   #s.add_dependency "fullcalendar-rails"
   #s.add_dependency 'mail', '2.5.4'
-  s.add_dependency 'unitwise'
+  s.add_dependency 'unitwise', '~> 2.0.0'
   s.add_dependency 'chronic'
   s.add_dependency "breadcrumbs_on_rails"
   s.add_dependency 'state_machine'


### PR DESCRIPTION
Fix two issues related to updated gems:
1. Unitwise changed its conversions. Locked to 2.0.0 to keep stable.
2. Rack::Test::UploadedFile.new now defaults to "text/plain" if not given a content type. Specified "image/png" for the uploaded test image.